### PR TITLE
Remove addition of local migration path

### DIFF
--- a/lib/coupons/engine.rb
+++ b/lib/coupons/engine.rb
@@ -4,10 +4,6 @@ module Coupons
 
     initializer 'coupons.append_migrations' do |app|
       next if app.root.to_s == root.to_s
-
-      config.paths['db/migrate'].expanded.each do |path|
-        app.config.paths['db/migrate'].push(path)
-      end
     end
 
     initializer 'coupons.assets' do |app|


### PR DESCRIPTION
This seems to be causing an `ActiveRecord:DuplicateMigrationNameError` because
`rake db:migrate` sees the migration in the local gem migration directory as
well as the copied migration.
